### PR TITLE
refactor, test: 로그인 시도를 5번 이상 실패하면 30분 동안 로그인을 할 수 없도록 한다.

### DIFF
--- a/authentication/src/main/java/project/goorm/authentication/business/common/filter/SessionValidationFilter.java
+++ b/authentication/src/main/java/project/goorm/authentication/business/common/filter/SessionValidationFilter.java
@@ -16,12 +16,14 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
+import static project.goorm.authentication.business.core.domain.common.error.CommonTypeException.LOGIN_FORBIDDEN_EXCEPTION;
 import static project.goorm.authentication.business.core.domain.member.MemberTypeException.ALREADY_LOGINED_EXCEPTION;
 
 @Component
 public class SessionValidationFilter implements Filter {
 
     private static final String SESSION_ID = "SESSION_ID";
+    private static final String INVALID_SESSION_ID = "INVALID_SESSION_ID";
 
     private final RedisSessionService sessionService;
     private final ObjectMapper objectMapper;
@@ -35,21 +37,47 @@ public class SessionValidationFilter implements Filter {
     }
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
-        String session = getSession(request);
-        if (session == null) {
+    public void doFilter(
+            ServletRequest request,
+            ServletResponse response,
+            FilterChain chain
+    ) throws ServletException, IOException {
+        String invalidSessionId = getInvalidSessionId(request);
+        if (invalidSessionId != null) {
+            forbiddenAccess(response);
+            return;
+        }
+        String sessionId = getSessionId(request);
+        if (sessionId == null) {
             chain.doFilter(request, response);
             return;
         }
-        Long memberId = sessionService.getMemberId(session);
+        Long memberId = sessionService.getMemberId(sessionId);
         if (memberId == null) {
             chain.doFilter(request, response);
             return;
         }
-        accessDeny(response);
+        denyAccess(response);
     }
 
-    private String getSession(ServletRequest servletRequest) {
+    private String getInvalidSessionId(ServletRequest servletRequest) {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+        Cookie[] cookies = httpServletRequest.getCookies();
+        if (cookies == null) {
+            return null;
+        }
+        Cookie sessionCookie = Arrays.stream(httpServletRequest.getCookies())
+                .filter(hasInvalidSessionId())
+                .findAny()
+                .orElseGet(() -> null);
+        return sessionCookie == null ? null : sessionCookie.getValue();
+    }
+
+    private Predicate<Cookie> hasInvalidSessionId() {
+        return cookie -> cookie.getName().equals(INVALID_SESSION_ID);
+    }
+
+    private String getSessionId(ServletRequest servletRequest) {
         HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
         Cookie[] cookies = httpServletRequest.getCookies();
         if (cookies == null) {
@@ -66,10 +94,17 @@ public class SessionValidationFilter implements Filter {
         return cookie -> cookie.getName().equals(SESSION_ID);
     }
 
-    private void accessDeny(ServletResponse response) throws IOException {
+    private void denyAccess(ServletResponse response) throws IOException {
         HttpServletResponse httpServletResponse = (HttpServletResponse) response;
         httpServletResponse.setCharacterEncoding("UTF-8");
         httpServletResponse.setStatus(ALREADY_LOGINED_EXCEPTION.getCode());
         httpServletResponse.getWriter().write(ALREADY_LOGINED_EXCEPTION.getMessage());
+    }
+
+    private void forbiddenAccess(ServletResponse response) throws IOException {
+        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+        httpServletResponse.setCharacterEncoding("UTF-8");
+        httpServletResponse.setStatus(LOGIN_FORBIDDEN_EXCEPTION.getCode());
+        httpServletResponse.getWriter().write(LOGIN_FORBIDDEN_EXCEPTION.getMessage());
     }
 }

--- a/authentication/src/main/java/project/goorm/authentication/business/core/domain/common/error/CommonTypeException.java
+++ b/authentication/src/main/java/project/goorm/authentication/business/core/domain/common/error/CommonTypeException.java
@@ -6,6 +6,7 @@ import project.goorm.authentication.common.exception.common.BaseExceptionType;
 public enum CommonTypeException implements BaseExceptionType {
 
     NUMBER_FORMAT_EXCEPTION(400, "회원 아이디가 올바르지 않습니다.", HttpStatus.BAD_REQUEST),
+    LOGIN_FORBIDDEN_EXCEPTION(403, "일정 기간 내 로그인 시도 횟수를 초과했습니다.", HttpStatus.FORBIDDEN),
     REDIS_WRONG_TYPE_DATASTRUCTURE_EXCEPTION(502, "올바르지 않은 키를 입력했습니다.", HttpStatus.BAD_GATEWAY),
     REDIS_CONNECTION_FAILURE_EXCEPTION(502, "서버에 문제가 발생했습니다.", HttpStatus.BAD_GATEWAY);
 

--- a/authentication/src/main/java/project/goorm/authentication/business/web/member/application/service/LoginService.java
+++ b/authentication/src/main/java/project/goorm/authentication/business/web/member/application/service/LoginService.java
@@ -9,9 +9,10 @@ import project.goorm.authentication.business.core.domain.member.entity.values.Lo
 import project.goorm.authentication.business.core.domain.member.infrastructure.query.MemberQueryRepository;
 import project.goorm.authentication.business.web.client.redis.RedisSessionService;
 import project.goorm.authentication.business.web.member.application.LoginCommand;
+import project.goorm.authentication.common.exception.common.LoginForbiddenException;
 import project.goorm.authentication.common.exception.common.SSSTeamException;
 
-import static project.goorm.authentication.business.core.domain.member.MemberTypeException.FORBIDDEN_ACCESS;
+import static project.goorm.authentication.business.core.domain.common.error.CommonTypeException.LOGIN_FORBIDDEN_EXCEPTION;
 import static project.goorm.authentication.business.core.domain.member.MemberTypeException.INVALID_LOGIN_ID_EXCEPTION;
 import static project.goorm.authentication.business.core.domain.member.MemberTypeException.INVALID_PASSWORD_EXCEPTION;
 
@@ -45,7 +46,7 @@ public class LoginService implements LoginCommand {
         if (!passwordEncoder.matches(loginPassword.getLoginPassword(), member.getLoginPassword())) {
             Long failureCount = sessionCommand.getLoginTryCount(member.getMemberId());
             if (failureCount > 5) {
-                throw SSSTeamException.of(FORBIDDEN_ACCESS);
+                throw LoginForbiddenException.of(LOGIN_FORBIDDEN_EXCEPTION);
             }
             throw SSSTeamException.of(INVALID_PASSWORD_EXCEPTION);
         }

--- a/authentication/src/main/java/project/goorm/authentication/business/web/member/presentation/CookieUtils.java
+++ b/authentication/src/main/java/project/goorm/authentication/business/web/member/presentation/CookieUtils.java
@@ -3,10 +3,13 @@ package project.goorm.authentication.business.web.member.presentation;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
+import java.util.UUID;
+
 @Component
 public class CookieUtils {
 
     private static final String SESSION_ID = "SESSION_ID";
+    private static final String INVALID_SESSION_ID = "INVALID_SESSION_ID";
     private static final long FIFTEEN_MINUTE = 60 * 15;
 
     public String createCookie(String session) {
@@ -29,6 +32,18 @@ public class CookieUtils {
                 .secure(true)
                 .sameSite("Lax")
                 .maxAge(0)
+                .build()
+                .toString();
+    }
+
+    public static String createInvalidSessionCookie() {
+        return ResponseCookie.from(INVALID_SESSION_ID, UUID.randomUUID().toString())
+                .path("/")
+                .domain("SSS")
+                .httpOnly(true)
+                .secure(true)
+                .sameSite("Lax")
+                .maxAge(1800)
                 .build()
                 .toString();
     }

--- a/authentication/src/main/java/project/goorm/authentication/common/exception/ExceptionHandler.java
+++ b/authentication/src/main/java/project/goorm/authentication/common/exception/ExceptionHandler.java
@@ -1,11 +1,15 @@
 package project.goorm.authentication.common.exception;
 
 import org.springframework.boot.actuate.endpoint.invoke.MissingParametersException;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import project.goorm.authentication.common.exception.common.ErrorResponse;
+import project.goorm.authentication.common.exception.common.LoginForbiddenException;
 import project.goorm.authentication.common.exception.common.SSSTeamException;
 
+import static org.springframework.http.HttpHeaders.SET_COOKIE;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static project.goorm.authentication.business.web.member.presentation.CookieUtils.createInvalidSessionCookie;
 
 @RestControllerAdvice
 public class ExceptionHandler {
@@ -25,4 +29,10 @@ public class ExceptionHandler {
         return ErrorResponse.of(exception);
     }
 
+    @org.springframework.web.bind.annotation.ExceptionHandler(LoginForbiddenException.class)
+    public ResponseEntity<ErrorResponse> catchLoginForbiddenException(LoginForbiddenException exception) {
+        return ResponseEntity.status(403)
+                .header(SET_COOKIE, createInvalidSessionCookie())
+                .body(ErrorResponse.of(exception));
+    }
 }

--- a/authentication/src/main/java/project/goorm/authentication/common/exception/common/ErrorResponse.java
+++ b/authentication/src/main/java/project/goorm/authentication/common/exception/common/ErrorResponse.java
@@ -18,6 +18,13 @@ public class ErrorResponse {
         this.status = exception.getStatus();
     }
 
+    private ErrorResponse(LoginForbiddenException exception) {
+        this.eventTime = LocalDateTime.now();
+        this.code = exception.getCode();
+        this.message = exception.getMessage();
+        this.status = exception.getStatus();
+    }
+
     private ErrorResponse(
             HttpStatus status,
             String message
@@ -29,6 +36,10 @@ public class ErrorResponse {
     }
 
     public static ErrorResponse of(SSSTeamException exception) {
+        return new ErrorResponse(exception);
+    }
+
+    public static ErrorResponse of(LoginForbiddenException exception) {
         return new ErrorResponse(exception);
     }
 

--- a/authentication/src/main/java/project/goorm/authentication/common/exception/common/LoginForbiddenException.java
+++ b/authentication/src/main/java/project/goorm/authentication/common/exception/common/LoginForbiddenException.java
@@ -1,0 +1,33 @@
+package project.goorm.authentication.common.exception.common;
+
+import org.springframework.http.HttpStatus;
+
+public class LoginForbiddenException extends RuntimeException {
+
+    private final BaseExceptionType baseExceptionType;
+
+    private LoginForbiddenException(BaseExceptionType baseExceptionType) {
+        super(baseExceptionType.getMessage());
+        this.baseExceptionType = baseExceptionType;
+    }
+
+    public static LoginForbiddenException of(BaseExceptionType baseExceptionType) {
+        return new LoginForbiddenException(baseExceptionType);
+    }
+
+    public BaseExceptionType getBaseExceptionType() {
+        return baseExceptionType;
+    }
+
+    public int getCode() {
+        return baseExceptionType.getCode();
+    }
+
+    public String getMessage() {
+        return baseExceptionType.getMessage();
+    }
+
+    public HttpStatus getStatus() {
+        return baseExceptionType.getStatus();
+    }
+}

--- a/authentication/src/test/java/project/goorm/authentication/test/integrationtest/filter/SessionFilterTest.java
+++ b/authentication/src/test/java/project/goorm/authentication/test/integrationtest/filter/SessionFilterTest.java
@@ -60,4 +60,14 @@ class SessionFilterTest extends IntegrationTestBase {
 
         assertEquals(200, response.getStatus());
     }
+
+    @Test
+    @DisplayName("최대 로그인 시도 횟수를 넘은 사용자가 로그인을 시도하면 403 상태코드를 받는다.")
+    void when_max_login_count_exceed_member_try_login_then_statuscode_should_be_403() throws ServletException, IOException {
+        request.setCookies(new Cookie("INVALID_SESSION_ID", UUID.randomUUID().toString()));
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(FORBIDDEN.value(), response.getStatus());
+    }
 }


### PR DESCRIPTION
## :pushpin: 상세 내용
&nbsp;&nbsp; - 로그인 시도를 5번 이상 실패하면 30분 동안 로그인 할 수 없도록 한다.
&nbsp;&nbsp; - 레디스를 이용해 블랙리스트에 등록한다.
&nbsp;&nbsp; - 블랙리스트 목록 관리 통합 테스트를 작성한다.

<br/><br/><br/>

## 🫧 구현 사항
- [x] 로그인 불가 블랙리스트 등록 <br/>
- [x] 블랙리스트 목록 관리 통합 테스트 작성 <br/>
<br/><br/><br/><br/><br/><br/><br/>


## 🐳 레디스 TTL
로그인 시도를 5번 이상 실패 시 30분간 로그인을 시도하지 못하도록 구현했습니다. 이 과정에서 레디스의 TTL(Time To Live)을 사용했는데, increment에서 이슈가 있었습니다.

```java
@Service
public class SessionStoreService implements RedisSessionService {

    ......

    @Override
    public Long getLoginTryCount(Long memberId) {
        try {
            Long loginTryCount = loginCountRedisTemplate.opsForValue().increment(getLoginCountKey(memberId));
            if (loginTryCount == null) {
                loginCountRedisTemplate.opsForValue().set(getLoginCountKey(memberId), 1L, Duration.ofMinutes(30));
                return 1L;
            }
            loginCountRedisTemplate.opsForValue().set(getLoginCountKey(memberId), loginTryCount, Duration.ofMinutes(30));
            return loginTryCount;
        } catch (DataAccessException e) {
            throw SSSTeamException.of(REDIS_CONNECTION_FAILURE_EXCEPTION);
        }
    }

```

<br/><br/><br/><br/><br/><br/><br/>

레디스의 increment는 아래와 같이 얼마 동안 key/value를 보관할지에 대한 인자를 받지 않습니다. 따라서 increment만 사용하게 되면 레디스에 key가 영구 저장되는 문제가 발생합니다.

<img width="878" alt="스크린샷 2023-03-22 오전 3 08 39" src="https://user-images.githubusercontent.com/68409825/226702237-6fef1cd5-843a-433b-b61d-65b813960108.png">

<br/><br/><br/><br/><br/><br/><br/>

이 문제를 해결하기 위해 increment로 로그인 시도 횟수를 증가시키고 그 값을 받아온 후, 다시 한번 set으로 key/value의 저장 기간을 지정했습니다. 이렇게 되면 레디스에 총 두 번 접근하기 때문에 성능상 그렇게 좋지 않아 보입니다. 로그인 기능은 다른 조회에 비해 시도 횟수가 적지만 추후 사용자가 많아졌을 때에 대해 성능 이슈를 고려하고 더 나은 방법이 없는지 검토해봐야 할 것 같습니다. 

```java
@Service
public class SessionStoreService implements RedisSessionService {

    ......

    @Override
    public Long getLoginTryCount(Long memberId) {
        try {
            Long loginTryCount = loginCountRedisTemplate.opsForValue().increment(getLoginCountKey(memberId));
            if (loginTryCount == null) {
                loginCountRedisTemplate.opsForValue().set(getLoginCountKey(memberId), 1L, Duration.ofMinutes(30));
                return 1L;
            }
            loginCountRedisTemplate.opsForValue().set(getLoginCountKey(memberId), loginTryCount, Duration.ofMinutes(30));
            return loginTryCount;
        } catch (DataAccessException e) {
            throw SSSTeamException.of(REDIS_CONNECTION_FAILURE_EXCEPTION);
        }
    }

```

<br/><br/><br/><br/><br/><br/><br/>

`최대 로그인 시도 횟수를 초과한 사용자는 어떻게 제재할까?`에 대해 고민하다 httponly/secure와 같이 자바스크립트로 접근 불가능한 쿠키를 만들어 이를 통해 검증하도록 구현했습니다. 하지만 이는 IP를 고려하지 않았기 때문에 추후 조금 더 나은 로직으로 리팩토링해 봐야 할 것 같습니다.

```java
@Component
public class SessionValidationFilter implements Filter {

    ......

    @Override
    public void doFilter(
            ServletRequest request,
            ServletResponse response,
            FilterChain chain
    ) throws ServletException, IOException {
        String invalidSessionId = getInvalidSessionId(request);
        if (invalidSessionId != null) {
            forbiddenAccess(response);
            return;
        }
        String sessionId = getSessionId(request);
        if (sessionId == null) {
            chain.doFilter(request, response);
            return;
        }
        Long memberId = sessionService.getMemberId(sessionId);
        if (memberId == null) {
            chain.doFilter(request, response);
            return;
        }
        denyAccess(response);
    }

    ......
}
```
Closed Issue #8 