### PR TITLE
bug: 실제 환경과 테스트 환경에서의 레디스를 분리한다.

### DIFF
--- a/authentication/src/main/java/project/goorm/authentication/business/web/client/redis/SessionStoreService.java
+++ b/authentication/src/main/java/project/goorm/authentication/business/web/client/redis/SessionStoreService.java
@@ -23,13 +23,10 @@ import static project.goorm.authentication.business.core.domain.common.error.Com
 @Service
 public class SessionStoreService implements RedisSessionService {
 
-    @Resource(name = "sessionsRedisTemplate")
     private final RedisTemplate<String, Object> redisTemplate;
 
-    @Resource(name = "sessionRedisTemplate")
     private final StringRedisTemplate stringRedisTemplate;
 
-    @Resource(name = "loginCountRedisTemplate")
     private final RedisTemplate<String, Long> loginCountRedisTemplate;
 
     public SessionStoreService(

--- a/authentication/src/main/java/project/goorm/authentication/common/configuration/redis/RedisConfiguration.java
+++ b/authentication/src/main/java/project/goorm/authentication/common/configuration/redis/RedisConfiguration.java
@@ -3,8 +3,8 @@ package project.goorm.authentication.common.configuration.redis;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -23,9 +23,8 @@ public class RedisConfiguration {
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
-        redisStandaloneConfiguration.setHostName(host);
-        redisStandaloneConfiguration.setPort(port);
+        RedisClusterConfiguration redisStandaloneConfiguration = new RedisClusterConfiguration();
+        redisStandaloneConfiguration.clusterNode(host, port);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
     }
 

--- a/authentication/src/test/java/project/goorm/authentication/common/configuration/redis/EmbeddedRedisConfiguration.java
+++ b/authentication/src/test/java/project/goorm/authentication/common/configuration/redis/EmbeddedRedisConfiguration.java
@@ -1,7 +1,17 @@
 package project.goorm.authentication.common.configuration.redis;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.StringUtils;
 import redis.embedded.RedisServer;
@@ -18,7 +28,53 @@ public class EmbeddedRedisConfiguration {
 
     @Value("${spring.redis.port}")
     private int port;
+
+    @Value("${spring.redis.host}")
+    private String host;
+
     private RedisServer redisServer;
+
+    @Primary
+    @Bean("redisConnectionFactoryTest")
+    public RedisConnectionFactory redisConnectionFactoryTest() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Primary
+    @Bean(name = "sessionsRedisTemplateTest")
+    public RedisTemplate<String, Object> objectRedisTemplateTest() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactoryTest());
+        return redisTemplate;
+    }
+
+    @Primary
+    @Bean(name = "sessionRedisTemplateTest")
+    public StringRedisTemplate stringRedisTemplateTest(){
+        StringRedisTemplate stringRedisTemplate=new StringRedisTemplate();
+        stringRedisTemplate.setConnectionFactory(redisConnectionFactoryTest());
+        stringRedisTemplate.setKeySerializer(new StringRedisSerializer());
+        stringRedisTemplate.setValueSerializer(new StringRedisSerializer());
+        return stringRedisTemplate;
+    }
+
+    @Primary
+    @Bean(name = "loginCountRedisTemplateTest")
+    public RedisTemplate<String, Long> loginCountRedisTemplateTest() {
+        RedisTemplate<String, Long> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactoryTest());
+        return redisTemplate;
+    }
+
 
     @PostConstruct
     public void redisServer() throws IOException {

--- a/authentication/src/test/java/project/goorm/authentication/common/configuration/redis/RedisInitialization.java
+++ b/authentication/src/test/java/project/goorm/authentication/common/configuration/redis/RedisInitialization.java
@@ -7,22 +7,21 @@ import org.springframework.stereotype.Component;
 
 import javax.annotation.Resource;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.Set;
 
 @Component
 public class RedisInitialization {
 
     @Autowired
-    @Resource(name = "sessionsRedisTemplate")
+    @Resource(name = "sessionsRedisTemplateTest")
     private RedisTemplate<String, Object> redisTemplate;
 
     @Autowired
-    @Resource(name = "sessionRedisTemplate")
+    @Resource(name = "sessionRedisTemplateTest")
     private StringRedisTemplate stringRedisTemplate;
 
     @Autowired
-    @Resource(name = "loginCountRedisTemplate")
+    @Resource(name = "loginCountRedisTemplateTest")
     private RedisTemplate<String, Long> longRedisTemplate;
 
     public RedisTemplate<String, Object> getRedisTemplate() {


### PR DESCRIPTION
## 📌 상세 내용
운영 환경에서는 클러스터링 레디스를 사용한다. 그러나 테스트 환경에서는 하나의 레디스 서버를 쓰기 때문에 둘의 설정이 달라진다.
 그래서 이를 분리한다.

issue #25 

